### PR TITLE
Bug/chat receiving

### DIFF
--- a/backend/app/controllers/api/conversations_controller.rb
+++ b/backend/app/controllers/api/conversations_controller.rb
@@ -9,7 +9,7 @@ class Api::ConversationsController < ApplicationController
 
   # Get the current user's conversations
   def show
-    conversations = Conversation.where(user_1: params[:id])
+    conversations = Conversation.where(user_1: params[:id]).or(Conversation.where(user_2: params[:id]))
 
     structured_conversations = []
     conversations.each do | conversation |

--- a/client/src/components/chat/ChatWindow.jsx
+++ b/client/src/components/chat/ChatWindow.jsx
@@ -19,7 +19,8 @@ export default function ChatWindow({ conversations, currentUser, addNewMessageTo
 
   const findCorrespondentUser = (conversations, activeConversationID) => {
     const conversation = findActiveConversation(conversations, activeConversationID)
-    return conversation.user_2[0]
+    const correspondentUser = currentUser.id === conversation.user_1[0].id ? conversation.user_2[0] : conversation.user_1[0];
+    return correspondentUser;
   }
 
   const correspondentUser = findCorrespondentUser(conversations, activeConversationID)

--- a/client/src/components/chat/ConversationsList.jsx
+++ b/client/src/components/chat/ConversationsList.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import ConvoPreview from './ConvoPreview';
 
 
-export default function ConversationsList({conversations, handleReceivedConversation}) {
+export default function ConversationsList({conversations, handleReceivedConversation, currentUserId}) {
 
   const mapConversations = (conversations) => {
     const orderedConversations = conversations.sort(
@@ -19,11 +19,12 @@ export default function ConversationsList({conversations, handleReceivedConversa
     });
 
     return orderedConversations.map((conversation, i) => {
+      const correspondentUser = currentUserId === conversation.user_1[0].id ? conversation.user_2[0] : conversation.user_1[0];
       return (
-        <div className="ind-conv-preview-container">
-          <li key={conversation.id}>
+        <div className="ind-conv-preview-container" key={conversation.id}>
+          <li>
           <Link to={`/chat?id=${conversation.id}`}>
-            <ConvoPreview avatar={conversation.user_2[0].avatar_url} userName={conversation.user_2[0].name} conversation={conversation} latestMessageTime={latestMessageTime[i]}/>
+            <ConvoPreview avatar={correspondentUser.avatar_url} userName={correspondentUser.name} conversation={conversation} latestMessageTime={latestMessageTime[i]}/>
           </Link>
 
           </li>

--- a/client/src/components/chat/MessageArea.jsx
+++ b/client/src/components/chat/MessageArea.jsx
@@ -10,11 +10,11 @@ const orderedMessages = messages => {
     (a, b) => new Date(a.created_at) - new Date(b.created_at)
   );
   return sortedMessages.map(message => {
-    const user = message.user_id === currentUser.id ? user_1[0] : user_2[0]
+    const user = message.user_id === user_1[0].id ? user_1[0] : user_2[0];
 
     return (
-      <div className="ind-message-container">
-        <li key={message.id}>
+      <div className="ind-message-container" key={message.id}>
+        <li>
           <img
             className="message-area-avatar"
             src={user.avatar_url}

--- a/client/src/components/profile/Closet.jsx
+++ b/client/src/components/profile/Closet.jsx
@@ -5,10 +5,9 @@ export default function Closet({ allClothing, currentUserId, userName }) {
     return clothingList
                     .filter(item => item.user_id === userId)
                     .map(item => (
-                      <div className="item_image_container">
+                      <div key={item.id} className="item_image_container">
                         <img
                           className="item_image"
-                          key={item.id}
                           src={item.image_url}
                           alt={"Clothing item of: " + userName}
                         ></img>

--- a/client/src/components/profile/Index.jsx
+++ b/client/src/components/profile/Index.jsx
@@ -72,7 +72,7 @@ export default function Profile(props) {
       </header>
       <main>
         <div className="profile-feed-placeholder">
-          {tab === "convos" && conversations && <ConversationsList conversations={conversations} handleReceivedConversation={handleReceivedConversation}/>}
+          {tab === "convos" && conversations && <ConversationsList conversations={conversations} handleReceivedConversation={handleReceivedConversation} currentUserId={currentUserId}/>}
           {tab === "closet" && allClothing && 
             <Closet
             currentUserId={currentUserId}


### PR DESCRIPTION
Fixed bug where if you were not user 1, you were not seeing your conversations on your profile as the backend was only checking the user_1 colum for the currentUserId. 

A few more bugs emerged after solving this. Fixed logic on the front end to properly check if you are user_1 or user_2 in the conversation for rendering the convoPreview, chatWindow header, and in the messageArea. 